### PR TITLE
chore(package): replace caret (^) with tilde (~) for grunt-contrib-jade ...

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ $ npm test
 
 ## Release History
 
+- **0.1.7** `2014.04.22`
+    - Replace caret (^) with tilde (~) for grunt-contrib-jade version
 - **0.1.5** `2013.01.07`
     - Fix #4
 - **0.1.4** `2013.01.03`

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-jade-i18n",
   "description": "Compile Jade templates via Grunt with internalization support",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "homepage": "https://github.com/adesisnetlife/grunt-jade-i18n",
   "author": {
     "name": "Tomas Aparicio",
@@ -28,7 +28,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "grunt-contrib-jade": "^0.11.0",
+    "grunt-contrib-jade": "~0.11.0",
     "lodash": "~2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Replace caret (^) with tilde (~) for grunt-contrib-jade version to keep older npm and node versions on environments when you can´t update the versions easily and quickcly.
