### PR TITLE
Add locale folders option

### DIFF
--- a/tasks/i18n.coffee
+++ b/tasks/i18n.coffee
@@ -21,11 +21,12 @@ module.exports = (grunt) ->
 
     options = @options()
     options.i18n = {} unless options.i18n
-    { locales, namespace, localeExtension, defaultExt } = options.i18n
+    { locales, namespace, localeExtension, defaultExt, localeFolders } = options.i18n
 
     # set default options
     namespace = '$i18n' unless namespace?
     localeExtension = no unless localeExtension?
+    localeFolders   = no unless localeFolders?
     defaultExt = '.html' unless defaultExt?
 
     if locales and locales.length
@@ -70,6 +71,8 @@ module.exports = (grunt) ->
         config.files = _.cloneDeep(@files).map (file) ->
           if localeExtension
             addLocaleExtensionDest file, locale, defaultExt
+          if localeFolders
+            addLocaleFolderDest file, locale, defaultExt
           else
             addLocaleDirnameDest file, locale, defaultExt
           file
@@ -113,6 +116,22 @@ module.exports = (grunt) ->
     else
       dest += setExtension outputExt
 
+    file.dest = file.orig.dest = dest
+
+  addLocaleFolderDest = (file, locale, outputExt) ->
+    throw new TypeError 'Missing the tuna destination path' unless file.dest
+
+    if ext = getExtension file.dest
+      relative = file.dest.slice(file.orig.dest.length + 1)
+      dest = path.join file.orig.dest, locale, path.dirname(relative), path.basename(relative, ext) + setExtension ext
+    else
+      if /(\/|\*+)$/i.test file.dest
+        base = file.dest.split('/')
+        dest = path.join path.join.apply(null, base.slice(0, -1)), locale, base.slice(-1).shift()
+      else
+        dest = path.join file.dest, locale
+
+    dest = dest.replace /\.jade$/i, setExtension outputExt
     file.dest = file.orig.dest = dest
 
   addLocaleDirnameDest = (file, locale, outputExt) ->

--- a/tasks/i18n.coffee
+++ b/tasks/i18n.coffee
@@ -119,17 +119,18 @@ module.exports = (grunt) ->
     file.dest = file.orig.dest = dest
 
   addLocaleFolderDest = (file, locale, outputExt) ->
-    throw new TypeError 'Missing the tuna destination path' unless file.dest
+    throw new TypeError 'Missing the template destination path' unless file.dest
+
+    relative = file.dest.slice file.orig.dest.length + 1
 
     if ext = getExtension file.dest
-      relative = file.dest.slice(file.orig.dest.length + 1)
       dest = path.join file.orig.dest, locale, path.dirname(relative), path.basename(relative, ext) + setExtension ext
     else
-      if /(\/|\*+)$/i.test file.dest
-        base = file.dest.split('/')
-        dest = path.join path.join.apply(null, base.slice(0, -1)), locale, base.slice(-1).shift()
+      if /(\/|\*+)$/i.test relative
+        base = relative.split('/')
+        dest = path.join file.orig.dest, locale, path.join.apply(null, base.slice(0, -1)), base.slice(-1).shift()
       else
-        dest = path.join file.dest, locale
+        dest = path.join file.orig.dest, locale, relative
 
     dest = dest.replace /\.jade$/i, setExtension outputExt
     file.dest = file.orig.dest = dest


### PR DESCRIPTION
This will add a `localeFolders` option.

Setting this option to `true` will allow to structure the locales as root for all the web, instead of having a locale folder in each subfolder.

```
$ tree
.
├── en
│   ├── aboutus
│   │   └── index.html
│   └── index.html
└── es
    ├── aboutus
    │   └── index.html
    └── index.html
```